### PR TITLE
Zig 0.13 compat

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -5,14 +5,12 @@ pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
 
     // Export as module to be available for @import("pretty") on user site
-    _ = b.addModule("pretty", .{ .root_source_file = .{
-        .path = "src/pretty.zig",
-    } });
+    _ = b.addModule("pretty", .{ .root_source_file = b.path("src/pretty.zig) });
 
     // Compile library
     const lib = b.addStaticLibrary(.{
         .name = "pretty",
-        .root_source_file = .{ .path = "src/pretty.zig" },
+        .root_source_file = b.path("src/pretty.zig"),
         .target = target,
         .optimize = optimize,
     });
@@ -21,7 +19,7 @@ pub fn build(b: *std.Build) void {
     // Run tests
     const tests = b.addTest(.{
         .name = "tests",
-        .root_source_file = .{ .path = "src/tests.zig" },
+        .root_source_file = b.path("src/tests.zig"),
         .target = target,
         .optimize = optimize,
     });
@@ -32,7 +30,7 @@ pub fn build(b: *std.Build) void {
     // Run demo
     const demo = b.addExecutable(.{
         .name = "demo",
-        .root_source_file = .{ .path = "src/demo.zig" },
+        .root_source_file = b.path("src/demo.zig"),
         .target = target,
         .optimize = optimize,
     });

--- a/build.zig
+++ b/build.zig
@@ -5,7 +5,7 @@ pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
 
     // Export as module to be available for @import("pretty") on user site
-    _ = b.addModule("pretty", .{ .root_source_file = b.path("src/pretty.zig) });
+    _ = b.addModule("pretty", .{ .root_source_file = b.path("src/pretty.zig") });
 
     // Compile library
     const lib = b.addStaticLibrary(.{


### PR DESCRIPTION
Closes #7. With these changes, `pretty` builds with Zig 0.13.0 on macOS.