### PR TITLE
Fix filter compile error

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -41,6 +41,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
+    demo.linkLibC();
     const step_demo = b.addRunArtifact(demo);
 
     b.step("run", "Run pretty demo").dependOn(&step_demo.step);

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .pretty,
     .fingerprint = 0x478ad1aafb96e4e,
-    .version = "0.10.4",
+    .version = "0.10.5",
     .paths = .{
         "src",
         "build.zig",

--- a/src/pretty.zig
+++ b/src/pretty.zig
@@ -798,7 +798,7 @@ fn Pretty(opt: Options) type {
 /// An interface that allows checking the inclusion or exclusion of items of
 /// a specified type.
 fn Filter(T: type) type {
-    return union(enum) {
+    return union(enum(usize)) {
         include: []const T,
         exclude: []const T,
         fn includes(s: @This(), item: T) bool {


### PR DESCRIPTION
On 64bit Linux I was running into two issues, this PR fixes those issues for me.

1. Compile error: `[@enumFromInt(22508)]: 8 != 1`. This is related to `Filter(type)`. I think this might be a compiler bug, so I filed an issue (https://github.com/ziglang/zig/issues/25944). There is a workaround to just make it an `enum(usize)`, which forces the union size to something that doesn't err.
2. Linking error for libc. I just needed to add a `linkLibC` in the build.

If you have any questions or issues with this PR, just let me know. Thanks.