### PR TITLE
Support `[*c]u8` and `[*c]const u8` as strings

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .pretty,
     .fingerprint = 0x478ad1aafb96e4e,
-    .version = "0.10.4",
+    .version = "0.10.6",
     .paths = .{
         "src",
         "build.zig",

--- a/src/pretty.zig
+++ b/src/pretty.zig
@@ -124,7 +124,7 @@ pub const Options = struct {
     /// Treat `[*:0]u8` as `"string"`.
     ptr_many_u8z_is_str: bool = true,
     /// Treat `[*c]u8` as `"string"`.
-    c_ptr_u8_is_str: bool = true,
+    ptr_c_u8_is_str: bool = true,
 
     // TODO
     // show_colors
@@ -551,11 +551,16 @@ fn Pretty(opt: Options) type {
                             }
                         },
                         .c => {
-                            if (opt.c_ptr_u8_is_str) {
-                                try s.appendValString(
-                                    if (val == null) "null" else std.mem.span(val),
-                                    c,
-                                );
+                            // [Option] Interpret [*c]u8 as string
+                            if (opt.ptr_c_u8_is_str) {
+                                if (val == null) {
+                                    try s.appendVal("null", c);
+                                } else {
+                                    try s.appendValString(
+                                        std.mem.span(val),
+                                        c,
+                                    );
+                                }
                             } else {
                                 // Can't follow C pointers
                                 try s.appendValSpecial(.unknown, c);

--- a/src/pretty.zig
+++ b/src/pretty.zig
@@ -552,7 +552,10 @@ fn Pretty(opt: Options) type {
                         },
                         .c => {
                             if (opt.c_ptr_u8_is_str) {
-                                try s.appendValString(std.mem.span(val), c);
+                                try s.appendValString(
+                                    if (val == null) "null" else std.mem.span(val),
+                                    c,
+                                );
                             } else {
                                 // Can't follow C pointers
                                 try s.appendValSpecial(.unknown, c);

--- a/src/pretty.zig
+++ b/src/pretty.zig
@@ -123,6 +123,8 @@ pub const Options = struct {
     array_u8z_is_str: bool = true,
     /// Treat `[*:0]u8` as `"string"`.
     ptr_many_u8z_is_str: bool = true,
+    /// Treat `[*c]u8` as `"string"`.
+    c_ptr_u8_is_str: bool = true,
 
     // TODO
     // show_colors
@@ -549,8 +551,12 @@ fn Pretty(opt: Options) type {
                             }
                         },
                         .c => {
-                            // Can't follow C pointers
-                            try s.appendValSpecial(.unknown, c);
+                            if (opt.c_ptr_u8_is_str) {
+                                try s.appendValString(std.mem.span(val), c);
+                            } else {
+                                // Can't follow C pointers
+                                try s.appendValSpecial(.unknown, c);
+                            }
                         },
                         .many => {
                             // [Option] Interpret [*:0]u8 as string

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -593,6 +593,20 @@ test {
         .c_ptr_u8_is_str = true,
     });
 
+    try case.run(@as([*c]u8, null),
+        \\[*c]u8
+        \\  "null"
+    , .{
+        .c_ptr_u8_is_str = true,
+    });
+
+    try case.run(@as([*c]const u8, null),
+        \\[*c]const u8
+        \\  "null"
+    , .{
+        .c_ptr_u8_is_str = true,
+    });
+
     try case.run(@as([:0]const u8, "pretty"),
         \\[:0]const u8
         \\  [0]: 112

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+
 const pretty = @import("pretty.zig");
 
 test {
@@ -583,28 +584,28 @@ test {
         \\[*c]const u8
         \\  "pretty"
     , .{
-        .c_ptr_u8_is_str = true,
+        .ptr_c_u8_is_str = true,
     });
 
     try case.run(@as([*c]u8, @constCast("pretty")),
         \\[*c]u8
         \\  "pretty"
     , .{
-        .c_ptr_u8_is_str = true,
+        .ptr_c_u8_is_str = true,
     });
 
     try case.run(@as([*c]u8, null),
         \\[*c]u8
-        \\  "null"
+        \\  null
     , .{
-        .c_ptr_u8_is_str = true,
+        .ptr_c_u8_is_str = true,
     });
 
     try case.run(@as([*c]const u8, null),
         \\[*c]const u8
-        \\  "null"
+        \\  null
     , .{
-        .c_ptr_u8_is_str = true,
+        .ptr_c_u8_is_str = true,
     });
 
     try case.run(@as([:0]const u8, "pretty"),

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -579,6 +579,20 @@ test {
         .slice_u8z_is_str = true,
     });
 
+    try case.run(@as([*c]const u8, "pretty"),
+        \\[*c]const u8
+        \\  "pretty"
+    , .{
+        .c_ptr_u8_is_str = true,
+    });
+
+    try case.run(@as([*c]u8, @constCast("pretty")),
+        \\[*c]u8
+        \\  "pretty"
+    , .{
+        .c_ptr_u8_is_str = true,
+    });
+
     try case.run(@as([:0]const u8, "pretty"),
         \\[:0]const u8
         \\  [0]: 112


### PR DESCRIPTION
Wanted to use this for debugging some C interop code, and this appears to work well. Tests passing on Zig version 0.15.2.

Thanks, and let me know if you have any feedback!

